### PR TITLE
mxstafa/[Bug Fix] signal-graph-node only process graph data if connected to source-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Currently working on:
 
 Quick start:
 
-1. `npm install`
-2. `npm run dev`
+1. Run `npm install` to install node dependencies
+2. Run `npm run dev` to start react app on [http://localhost:3000/](http://localhost:3000/)
+3. Open another terminal and run `node server.js` to start mock server to send signals
 
 References:
 

--- a/components/nodes/signal-graph-node/signal-graph-node.tsx
+++ b/components/nodes/signal-graph-node/signal-graph-node.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@/components/ui/card';
-import { Handle, Position } from '@xyflow/react';
+import { getIncomers, Handle, Node, Position, useReactFlow } from '@xyflow/react';
 import SignalGraphPreview from './signal-graph-preview';
 import useWebsocket from '@/hooks/useWebsocket';
 
@@ -25,6 +25,27 @@ export default function SignalGraphNode() {
         signal5: item.signals[4],
     }));
 
+    const { getEdges, getNodes } = useReactFlow();
+    const nodes = getNodes();
+    const edges = getEdges();
+
+    const areNodeTypesConnected = (nodes: any[], edges: any[], typeA: string, typeB: string) => {
+        const nodeMap = Object.fromEntries(nodes.map((n) => [n.id, n]));
+      
+        return edges.some((edge) => {
+          const sourceNode = nodeMap[edge.source];
+          const targetNode = nodeMap[edge.target];
+      
+          return (sourceNode?.type === typeA && targetNode?.type === typeB);
+        });
+    };
+
+    const connected = areNodeTypesConnected(nodes, edges, 'source-node', 'signal-graph-node');
+
+    if (connected) {
+        console.log('At least one inputNode is connected to an outputNode');
+    }       
+
     return (
         <Card>
             <Handle type="target" position={Position.Left} />
@@ -32,7 +53,7 @@ export default function SignalGraphNode() {
             <Dialog>
                 <DialogTrigger>
                     <div className="w-[400px] h-[400px]">
-                        <SignalGraphPreview data={processedData} />
+                        <SignalGraphPreview data={connected? processedData : []} />
                     </div>
                 </DialogTrigger>
                 <DialogContent className="w-[80vw] h-[80vh] max-w-none max-h-none">
@@ -44,7 +65,7 @@ export default function SignalGraphNode() {
                     </DialogHeader>
                     <Card>
                         <div className="w-full h-full">
-                            <SignalGraphView data={processedData} />
+                            <SignalGraphView data={connected? processedData : []} />
                         </div>
                     </Card>
                 </DialogContent>


### PR DESCRIPTION
# Pull Request Template

## What?

Fixed graph signals to show graph visual only if a source node is connected to it the graph signal node

---

## How?

Added a new condition to check if there exists an edge from any source node to any signal graph node

**Note**: this is a loose check, although good enough for MVP, might cause unknown behaviour to all nodes on the viewport without hard check.

#### What is hard check?
1. compare nodes by `id` instead of `nodeType`

---

## Testing

List ways you have tested the code.

- Did testing through console.logs
- Tested live on app to check for the determined behaviour

---
